### PR TITLE
Docs: Add Status Badges to main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Quarkus & GraalVM Communication Patterns Lab
 
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/33df58ded13c4bf39ef8bc99670b7570)](https://app.codacy.com/gh/apenlor/quarkus-communication-patterns-lab/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
+[![CI Build Status](https://github.com/apenlor/quarkus-communication-patterns-lab/actions/workflows/ci.yml/badge.svg)](https://github.com/apenlor/quarkus-communication-patterns-lab/actions/workflows/ci.yml)
+[![Latest Tag](https://img.shields.io/github/v/tag/apenlor/quarkus-communication-patterns-lab)](https://github.com/apenlor/quarkus-communication-patterns-lab/tags)
+[![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+
 A repository that systematically demonstrates, benchmarks, and compares common client-server communication patterns on
 the Quarkus framework. The core objective is to contrast the performance characteristics (startup time, memory usage,
 throughput, latency) of the standard JVM runtime versus a GraalVM native executable.


### PR DESCRIPTION
This pull request enhances the main README.md by adding a suite of status badges to the top of the document.

The purpose of these badges is to provide a quick, at-a-glance dashboard of the project's quality, status, and metadata, which is a standard practice for professional repositories.

The following badges have been added:

- Code Quality: Integrates the Codacy badge to provide an objective grade from our static analysis tool.
- CI Build Status: Shows the live pass/fail status of the main branch from our GitHub Actions workflow.
- Latest Tag: Displays the tags and links directly to the GitHub tag page.
- License: Clearly communicates that the project is available under the MIT License.