### PR TITLE
ci(release): update & improve workflow for release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Create and Publish Release
+name: Create & publish release
 
 on:
   # Trigger automatically for v* tags
@@ -44,7 +44,11 @@ jobs:
           REPO_NAME: ${{ github.event.repository.name }}
         run: |
           ARCHIVE_NAME="${REPO_NAME}-${TAG}.tar.gz"
-          tar -czvf "${ARCHIVE_NAME}" --exclude='.git' --exclude="${ARCHIVE_NAME}" .
+          tar --sort=name --mtime='UTC 2020-01-01' \
+              --owner=0 --group=0 --numeric-owner \
+              --ignore-failed-read --warning=no-file-changed \
+              -czf "${ARCHIVE_NAME}" \
+              --exclude='.git' --exclude="${ARCHIVE_NAME}" .
           echo "ARCHIVE_NAME=${ARCHIVE_NAME}" >> $GITHUB_ENV
           echo "Created archive: ${ARCHIVE_NAME}"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,12 +5,6 @@ on:
   push:
     tags:
       - 'v*.*'
-  # Allow manual triggering for backfilling old releases
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: 'The tag to create a release for (e.g., v1.0-rest)'
-        required: true
 
 jobs:
   build-and-release:
@@ -20,27 +14,13 @@ jobs:
       contents: write
 
     steps:
-      - name: Determine tag name
-        id: get_tag
-        env:
-          INPUT_TAG: ${{ github.event.inputs.tag }}
-          REF_TAG: ${{ github.ref_name }}
-        run: |
-          if [ -n "$INPUT_TAG" ]; then
-            echo "TAG_NAME=$INPUT_TAG" >> $GITHUB_OUTPUT
-          else
-            echo "TAG_NAME=$REF_TAG" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Checkout code at the specified tag
+      - name: Checkout code
         # actions/checkout@v5.0.0
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
-        with:
-          ref: ${{ steps.get_tag.outputs.TAG_NAME }}
+        uses: actions/checkout@v4
 
       - name: Create source code archive
         env:
-          TAG: ${{ steps.get_tag.outputs.TAG_NAME }}
+          TAG: ${{ github.ref_name }}
           REPO_NAME: ${{ github.event.repository.name }}
         run: |
           ARCHIVE_NAME="${REPO_NAME}-${TAG}.tar.gz"
@@ -57,13 +37,10 @@ jobs:
           sha256sum "${{ env.ARCHIVE_NAME }}" > SHA256SUMS.txt
           echo "Calculated checksums."
 
-      - name: Create or update GitHub Release
+      - name: Create GitHub Release
         #softprops/action-gh-release@2.3.3
         uses: softprops/action-gh-release@6cbd405e2c4e67a21c47fa9e383d020e4e28b836
-        env:
-          TAG: ${{ steps.get_tag.outputs.TAG_NAME }}
         with:
-          tag_name: ${{ env.TAG }}
           files: |
             ${{ env.ARCHIVE_NAME }}
             SHA256SUMS.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,57 @@
+name: Create and Publish Release
+
+on:
+  # Trigger automatically for v* tags
+  push:
+    tags:
+      - 'v*.*'
+  # Allow manual triggering for backfilling old releases
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'The tag to create a release for (e.g., v1.0-rest)'
+        required: true
+
+jobs:
+  build-and-release:
+    name: Build and Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Determine tag name
+        id: get_tag
+        run: |
+          TAG_NAME="${{ github.event.inputs.tag || github.ref_name }}"
+          echo "Processing tag: ${TAG_NAME}"
+          echo "TAG_NAME=${TAG_NAME}" >> $GITHUB_ENV
+
+      - name: Checkout code at the specified tag
+        # actions/checkout@v5.0.0
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          ref: ${{ env.TAG_NAME }}
+
+      - name: Create source code archive
+        run: |
+          ARCHIVE_NAME="${{ github.event.repository.name }}-${{ env.TAG_NAME }}.tar.gz"
+          tar -czvf "${ARCHIVE_NAME}" --exclude='.git' .
+          echo "ARCHIVE_NAME=${ARCHIVE_NAME}" >> $GITHUB_ENV
+          echo "Created archive: ${ARCHIVE_NAME}"
+
+      - name: Calculate checksums
+        run: |
+          sha256sum "${{ env.ARCHIVE_NAME }}" > SHA256SUMS.txt
+          echo "Calculated checksums."
+
+      - name: Create or update GitHub Release
+        #softprops/action-gh-release@2.3.3
+        uses: softprops/action-gh-release@6cbd405e2c4e67a21c47fa9e383d020e4e28b836
+        with:
+          tag_name: ${{ env.TAG_NAME }}
+          files: |
+            ${{ env.ARCHIVE_NAME }}
+            SHA256SUMS.txt
+          allow_override: true
+          generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,20 +22,28 @@ jobs:
     steps:
       - name: Determine tag name
         id: get_tag
+        env:
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+          REF_TAG: ${{ github.ref_name }}
         run: |
-          TAG_NAME="${{ github.event.inputs.tag || github.ref_name }}"
-          echo "Processing tag: ${TAG_NAME}"
-          echo "TAG_NAME=${TAG_NAME}" >> $GITHUB_ENV
+          if [ -n "$INPUT_TAG" ]; then
+            echo "TAG_NAME=$INPUT_TAG" >> $GITHUB_OUTPUT
+          else
+            echo "TAG_NAME=$REF_TAG" >> $GITHUB_OUTPUT
+          fi
 
       - name: Checkout code at the specified tag
         # actions/checkout@v5.0.0
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
-          ref: ${{ env.TAG_NAME }}
+          ref: ${{ steps.get_tag.outputs.TAG_NAME }}
 
       - name: Create source code archive
+        env:
+          TAG: ${{ steps.get_tag.outputs.TAG_NAME }}
+          REPO_NAME: ${{ github.event.repository.name }}
         run: |
-          ARCHIVE_NAME="${{ github.event.repository.name }}-${{ env.TAG_NAME }}.tar.gz"
+          ARCHIVE_NAME="${REPO_NAME}-${TAG}.tar.gz"
           tar -czvf "${ARCHIVE_NAME}" --exclude='.git' .
           echo "ARCHIVE_NAME=${ARCHIVE_NAME}" >> $GITHUB_ENV
           echo "Created archive: ${ARCHIVE_NAME}"
@@ -48,8 +56,10 @@ jobs:
       - name: Create or update GitHub Release
         #softprops/action-gh-release@2.3.3
         uses: softprops/action-gh-release@6cbd405e2c4e67a21c47fa9e383d020e4e28b836
+        env:
+          TAG: ${{ steps.get_tag.outputs.TAG_NAME }}
         with:
-          tag_name: ${{ env.TAG_NAME }}
+          tag_name: ${{ env.TAG }}
           files: |
             ${{ env.ARCHIVE_NAME }}
             SHA256SUMS.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
           REPO_NAME: ${{ github.event.repository.name }}
         run: |
           ARCHIVE_NAME="${REPO_NAME}-${TAG}.tar.gz"
-          tar -czvf "${ARCHIVE_NAME}" --exclude='.git' .
+          tar -czvf "${ARCHIVE_NAME}" --exclude='.git' --exclude="${ARCHIVE_NAME}" .
           echo "ARCHIVE_NAME=${ARCHIVE_NAME}" >> $GITHUB_ENV
           echo "Created archive: ${ARCHIVE_NAME}"
 


### PR DESCRIPTION
This pull request performs a final cleanup and simplification of the `release.yml` workflow.

The `workflow_dispatch` trigger was a temporary mechanism, intentionally added to allow for the one-time task of backfilling releases for all historical tags (`v1.0-rest` through `v3.0-websockets`). With this backfilling process now complete, the manual trigger is obsolete and is being removed.